### PR TITLE
Fix closing tag in post layout

### DIFF
--- a/_includes/themes/bootstrap-3/post.html
+++ b/_includes/themes/bootstrap-3/post.html
@@ -38,7 +38,7 @@
     {% if page.next %}
       <li class="next"><a href="{{ BASE_PATH }}{{ page.next.url }}" title="{{ page.next.title }}">Next &raquo;</a></li>
     {% else %}
-      <li class="next disabled"><a>Next &rarr;</a>
+      <li class="next disabled"><a>Next &rarr;</a></li>
     {% endif %}
     </ul>
     <hr>


### PR DESCRIPTION
## Summary
- add missing closing `</li>` tag in the pagination block for posts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685bf4cbf4f48329bc15f079607f7319